### PR TITLE
Fix extract returning non-word character before hash-tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ function _getRegexMention(){
 	return new RegExp(/(?:^|[^a-zA-Z0-9_＠!@#$%&*])(?:(?:@|＠)(?!\/))([a-zA-Z0-9/_]{1,15})(?:\b(?!@|＠)|$)/igm);
 }
 function _getRegexHashtag(){
-	return new RegExp(/(?:^|[^a-zA-Z0-9_]+)(?:(?:#)(?!\/))([a-zA-Z0-9/_]+)(?:\b(?!#)|$)/igm);
+	return new RegExp(/(?:^|[^a-zA-Z0-9_])(?:(?:#)(?!\/))([a-zA-Z0-9/_]+)(?:\b(?!#)|$)/igm);
 }
 function _unique(arr){
 	return arr.filter((val, i, _arr) => _arr.indexOf(val) === i);

--- a/test.js
+++ b/test.js
@@ -47,6 +47,10 @@ describe('Extract Hashtags', () => {
 		assert.equal('hashtag', hashtags[0], `'text with 1 #hashtag' text and symbol is not required should be without #`);
 	});
 
+	it(`'text with hashtag! #hashtag' text with 1 hashtag including an exclamation mark before it`, () => {
+		const hashtags = extract('text with hashtag! #hashtag', '#');
+		assert.equal('#hashtag', hashtags[0], `'text with hashtag! #hashtag' should return proper hashtag`);
+	});
 });
 
 describe('Extract Mix', () => {


### PR DESCRIPTION
Hello,

While using the library, I ran into what seems to be a bug that causes certain characters to be returned as part of a hash-tag if they precede it. e.g: `extract('will this work? #ihopeitdoes', '#')` returns `?#ihopeitdoes` instead of just `#ihopeitdoes`. I managed to get it work by playing with the regex around. My "regex-fu" is not as strong, so please let me know if you think I've made a mistake.

For clarity, here's a visual representation of the issue:
<img width="675" alt="screen shot 2018-06-15 at 10 04 53 am" src="https://user-images.githubusercontent.com/2180822/41472153-9f5833f6-7083-11e8-8aa0-ea8f8efd728a.png">
